### PR TITLE
wemeet: remove fcitx from dependencies and mark 21.11 work.

### DIFF
--- a/pkgs/wemeet/default.nix
+++ b/pkgs/wemeet/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = !(versionAtLeast (versions.majorMinor trivial.version) "22.05");
+    broken = !(versionAtLeast (versions.majorMinor trivial.version) "21.11");
     homepage = https://meeting.tencent.com;
     description = "Tencent Video Conferencing, tencent meeting";
     license = licenses.unfree;

--- a/pkgs/wemeet/default.nix
+++ b/pkgs/wemeet/default.nix
@@ -59,8 +59,6 @@ stdenv.mkDerivation rec {
   ] ++ (with xorg; [
     libSM
     libX11
-  ]) ++ (with libsForQt5; [
-    fcitx-qt5
   ]);
 
   autoPatchelfIgnoreMissingDeps = [


### PR DESCRIPTION
**Fcitx-qt**
This is not necessary for fcitx5.

**Broken condition**
This can work under 21.11.

**Test environment**
nixos version: 21.11.20211207.1bd4bbd (Porcupine)
WM: xmonad
DE: none