### PR TITLE
Automated update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixos-stable": {
       "locked": {
-        "lastModified": 1674407282,
-        "narHash": "sha256-2qwc8mrPINSFdWffPK+ji6nQ9aGnnZyHSItVcYDZDlk=",
+        "lastModified": 1675061157,
+        "narHash": "sha256-F7/F65ZFWbq7cKSiV3K2acxCv64jKaZZ/K0A3VNT2kA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab1254087f4cdf4af74b552d7fc95175d9bdbb49",
+        "rev": "f413457e0dd7a42adefdbcea4391dd9751509025",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674459583,
-        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
+        "lastModified": 1674641431,
+        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
+        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
         "type": "github"
       },
       "original": {

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -27,11 +27,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-jG3pXSmC13Fd0Gnktmu+hQ7kAPp1LRPqL9HWpVbDjzA=",
+            "sha256": "sha256-FlwOzuBMyD5o8vfFQtaJl7Z+8m04HoxCnBoWnheoIDA=",
             "type": "url",
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.20.14/Clash.for.Windows-0.20.14-x64-linux.tar.gz"
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.20.15/Clash.for.Windows-0.20.15-x64-linux.tar.gz"
         },
-        "version": "0.20.14"
+        "version": "0.20.15"
     },
     "clash-for-windows-icon": {
         "cargoLocks": null,
@@ -57,11 +57,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-rLHyBKHiJ2sh3u1enMbCnuj9cvrblsG+6b+ItKaM8FU=",
+            "sha256": "sha256-7q/bumfaW4BNDBApUcllJa05zCjhIXZMrU0IzpGYdoI=",
             "type": "url",
-            "url": "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-arm64-2022.11.25.gz"
+            "url": "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-arm64-2023.01.29.gz"
         },
-        "version": "2022.11.25"
+        "version": "2023.01.29"
     },
     "clash-premium-i686-linux": {
         "cargoLocks": null,
@@ -72,11 +72,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-vQmsvcxWawzcUtUJ98S+h4214hxrVGEY58oDB5RLQx4=",
+            "sha256": "sha256-GwSWvKhk3bK06wQghOjJXpZPMU+r1GMZN3NCzNn++d4=",
             "type": "url",
-            "url": "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-386-2022.11.25.gz"
+            "url": "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-386-2023.01.29.gz"
         },
-        "version": "2022.11.25"
+        "version": "2023.01.29"
     },
     "clash-premium-x86_64-darwin": {
         "cargoLocks": null,
@@ -87,11 +87,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-aXs3/sJAfZDEpOnXY6RfMs6EHyNbUYOx7ZQJ4ONDMCM=",
+            "sha256": "sha256-RPx4dHs6VWDaGWIbpBtxlZaqwSJsiFHRmaND+ke3Z+c=",
             "type": "url",
-            "url": "https://github.com/Dreamacro/clash/releases/download/premium/clash-darwin-amd64-2022.11.25.gz"
+            "url": "https://github.com/Dreamacro/clash/releases/download/premium/clash-darwin-amd64-2023.01.29.gz"
         },
-        "version": "2022.11.25"
+        "version": "2023.01.29"
     },
     "clash-premium-x86_64-linux": {
         "cargoLocks": null,
@@ -102,11 +102,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-1s4K+rjlwWqXrCE2L8QveFL8CTgvGMYzniuZMgY1+eE=",
+            "sha256": "sha256-LCN9HNBZZ1oAIeLxm/NnMdnD5Hrw1STgisXOUdSYPaY=",
             "type": "url",
-            "url": "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-amd64-2022.11.25.gz"
+            "url": "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-amd64-2023.01.29.gz"
         },
-        "version": "2022.11.25"
+        "version": "2023.01.29"
     },
     "commit-notifier": {
         "cargoLocks": {

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -16,10 +16,10 @@
   };
   clash-for-windows = {
     pname = "clash-for-windows";
-    version = "0.20.14";
+    version = "0.20.15";
     src = fetchurl {
-      url = "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.20.14/Clash.for.Windows-0.20.14-x64-linux.tar.gz";
-      sha256 = "sha256-jG3pXSmC13Fd0Gnktmu+hQ7kAPp1LRPqL9HWpVbDjzA=";
+      url = "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.20.15/Clash.for.Windows-0.20.15-x64-linux.tar.gz";
+      sha256 = "sha256-FlwOzuBMyD5o8vfFQtaJl7Z+8m04HoxCnBoWnheoIDA=";
     };
   };
   clash-for-windows-icon = {
@@ -32,34 +32,34 @@
   };
   clash-premium-aarch64-linux = {
     pname = "clash-premium-aarch64-linux";
-    version = "2022.11.25";
+    version = "2023.01.29";
     src = fetchurl {
-      url = "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-arm64-2022.11.25.gz";
-      sha256 = "sha256-rLHyBKHiJ2sh3u1enMbCnuj9cvrblsG+6b+ItKaM8FU=";
+      url = "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-arm64-2023.01.29.gz";
+      sha256 = "sha256-7q/bumfaW4BNDBApUcllJa05zCjhIXZMrU0IzpGYdoI=";
     };
   };
   clash-premium-i686-linux = {
     pname = "clash-premium-i686-linux";
-    version = "2022.11.25";
+    version = "2023.01.29";
     src = fetchurl {
-      url = "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-386-2022.11.25.gz";
-      sha256 = "sha256-vQmsvcxWawzcUtUJ98S+h4214hxrVGEY58oDB5RLQx4=";
+      url = "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-386-2023.01.29.gz";
+      sha256 = "sha256-GwSWvKhk3bK06wQghOjJXpZPMU+r1GMZN3NCzNn++d4=";
     };
   };
   clash-premium-x86_64-darwin = {
     pname = "clash-premium-x86_64-darwin";
-    version = "2022.11.25";
+    version = "2023.01.29";
     src = fetchurl {
-      url = "https://github.com/Dreamacro/clash/releases/download/premium/clash-darwin-amd64-2022.11.25.gz";
-      sha256 = "sha256-aXs3/sJAfZDEpOnXY6RfMs6EHyNbUYOx7ZQJ4ONDMCM=";
+      url = "https://github.com/Dreamacro/clash/releases/download/premium/clash-darwin-amd64-2023.01.29.gz";
+      sha256 = "sha256-RPx4dHs6VWDaGWIbpBtxlZaqwSJsiFHRmaND+ke3Z+c=";
     };
   };
   clash-premium-x86_64-linux = {
     pname = "clash-premium-x86_64-linux";
-    version = "2022.11.25";
+    version = "2023.01.29";
     src = fetchurl {
-      url = "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-amd64-2022.11.25.gz";
-      sha256 = "sha256-1s4K+rjlwWqXrCE2L8QveFL8CTgvGMYzniuZMgY1+eE=";
+      url = "https://github.com/Dreamacro/clash/releases/download/premium/clash-linux-amd64-2023.01.29.gz";
+      sha256 = "sha256-LCN9HNBZZ1oAIeLxm/NnMdnD5Hrw1STgisXOUdSYPaY=";
     };
   };
   commit-notifier = {


### PR DESCRIPTION
###### Changelog

```text
clash-for-windows: 0.20.14 -> 0.20.15
clash-premium-aarch64-linux: 2022.11.25 -> 2023.01.29
clash-premium-i686-linux: 2022.11.25 -> 2023.01.29
clash-premium-x86_64-darwin: 2022.11.25 -> 2023.01.29
clash-premium-x86_64-linux: 2022.11.25 -> 2023.01.29
```