### PR TITLE
rimePackages/rimeDataBuildHook: fix permission issue

### DIFF
--- a/pkgs/rime-packages/hooks/rime-data-build-hook.sh
+++ b/pkgs/rime-packages/hooks/rime-data-build-hook.sh
@@ -23,7 +23,7 @@ function rimeDataBuildPreBuildHook {
     processed="$processed $data "
 
     echo "linking RIME dependency '$data'..."
-    cp --recursive --verbose "$data/share/rime-data/." rime_data_deps/
+    cp --no-preserve mode --recursive --verbose "$data/share/rime-data/." rime_data_deps/
   done
   echo "Finished executing rimeDataBuildPreBuildHook"
 }


### PR DESCRIPTION
Support rime package A depends package B and C, which B contains `share/rime-data/build/b` and C contains `share/rime-data/build/c`. In `rimeDataBuildHook`, it will first copy B then copy C. After copying B, directory `rime_data_deps/build/` would be read-only, so that copying C will raise an error.

Setting `--no-preseve mode` flag for `cp` fixes this issue.