### PR TITLE
moe-koe-music: fix AppImage URL template for v1.6.6+

### DIFF
--- a/pkgs/dev-packages/nvfetcher-self/src/Main.hs
+++ b/pkgs/dev-packages/nvfetcher-self/src/Main.hs
@@ -134,7 +134,7 @@ moeKoeMusic =
       `sourceGitHub` ("iAJue", "MoeKoeMusic")
       `fetchUrl` url
   where
-    url (Version v) = "https://github.com/iAJue/MoeKoeMusic/releases/download/" <> v <> "/MoeKoe_Music-x86_64.AppImage"
+    url (Version v) = "https://github.com/iAJue/MoeKoeMusic/releases/download/" <> v <> "/MoeKoe_Music_" <> v <> "-x86_64.AppImage"
 
 zeronsd :: PackageSet ()
 zeronsd =


### PR DESCRIPTION
MoeKoeMusic changed the release asset naming scheme starting from v1.6.6. The AppImage filename now includes the version number:

- **Before**: `MoeKoe_Music-x86_64.AppImage`
- **After**: `MoeKoe_Music_v1.6.6-x86_64.AppImage`

This fixes the nvfetcher auto-update failure.