### PR TITLE
Automated update

### DIFF
--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -82,12 +82,12 @@
             "name": null,
             "owner": "cowrie",
             "repo": "cowrie",
-            "rev": "v3.0.8",
-            "sha256": "sha256-JHi2ABNbWNwRRnDOD0pVeEyHPLg9Fzyx6QVqXUdz9SQ=",
+            "rev": "v3.0.9",
+            "sha256": "sha256-nARa3kU0rEVaBj32b9NstRkdEhhnoAmPjSbn831z+/I=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "v3.0.8"
+        "version": "v3.0.9"
     },
     "dot-tar": {
         "cargoLock": {
@@ -189,12 +189,12 @@
             "name": null,
             "owner": "intel",
             "repo": "linux-intel-lts",
-            "rev": "lts-v6.18.37-linux-260713T060441Z",
-            "sha256": "sha256-f3aIDE3XdqYNFntomuojMN+/oVxAA/zZbEfvCUnuNPY=",
+            "rev": "lts-v6.18.38-linux-260717T053932Z",
+            "sha256": "sha256-FmGNSw99iJuDyvEZtJhg6zDcMroWv5axpNUEINJmWpw=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "lts-v6.18.37-linux-260713T060441Z"
+        "version": "lts-v6.18.38-linux-260717T053932Z"
     },
     "linux-intel-mainline-tracking": {
         "cargoLock": null,
@@ -283,11 +283,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-0d3i3W34jQZu/so1HKGr1hX3T8UKkAyhF+GpNGK2bMU=",
+            "sha256": "sha256-R67YqEd1Tr8P+Zi9GbvExEWH2hBRltqO6FVYu2A0pLI=",
             "type": "url",
-            "url": "https://github.com/iAJue/MoeKoeMusic/releases/download/v1.6.8/MoeKoe_Music_v1.6.8-x86_64.AppImage"
+            "url": "https://github.com/iAJue/MoeKoeMusic/releases/download/v1.6.9/MoeKoe_Music_v1.6.9-x86_64.AppImage"
         },
-        "version": "v1.6.8"
+        "version": "v1.6.9"
     },
     "mstickereditor": {
         "cargoLock": {

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -50,13 +50,13 @@
   };
   cowrie = {
     pname = "cowrie";
-    version = "v3.0.8";
+    version = "v3.0.9";
     src = fetchFromGitHub {
       owner = "cowrie";
       repo = "cowrie";
-      rev = "v3.0.8";
+      rev = "v3.0.9";
       fetchSubmodules = false;
-      sha256 = "sha256-JHi2ABNbWNwRRnDOD0pVeEyHPLg9Fzyx6QVqXUdz9SQ=";
+      sha256 = "sha256-nARa3kU0rEVaBj32b9NstRkdEhhnoAmPjSbn831z+/I=";
     };
   };
   dot-tar = {
@@ -120,13 +120,13 @@
   };
   linux-intel-lts = {
     pname = "linux-intel-lts";
-    version = "lts-v6.18.37-linux-260713T060441Z";
+    version = "lts-v6.18.38-linux-260717T053932Z";
     src = fetchFromGitHub {
       owner = "intel";
       repo = "linux-intel-lts";
-      rev = "lts-v6.18.37-linux-260713T060441Z";
+      rev = "lts-v6.18.38-linux-260717T053932Z";
       fetchSubmodules = false;
-      sha256 = "sha256-f3aIDE3XdqYNFntomuojMN+/oVxAA/zZbEfvCUnuNPY=";
+      sha256 = "sha256-FmGNSw99iJuDyvEZtJhg6zDcMroWv5axpNUEINJmWpw=";
     };
   };
   linux-intel-mainline-tracking = {
@@ -172,10 +172,10 @@
   };
   moe-koe-music = {
     pname = "moe-koe-music";
-    version = "v1.6.8";
+    version = "v1.6.9";
     src = fetchurl {
-      url = "https://github.com/iAJue/MoeKoeMusic/releases/download/v1.6.8/MoeKoe_Music_v1.6.8-x86_64.AppImage";
-      sha256 = "sha256-0d3i3W34jQZu/so1HKGr1hX3T8UKkAyhF+GpNGK2bMU=";
+      url = "https://github.com/iAJue/MoeKoeMusic/releases/download/v1.6.9/MoeKoe_Music_v1.6.9-x86_64.AppImage";
+      sha256 = "sha256-R67YqEd1Tr8P+Zi9GbvExEWH2hBRltqO6FVYu2A0pLI=";
     };
   };
   mstickereditor = {

--- a/pkgs/deepseek-reasonix/default.nix
+++ b/pkgs/deepseek-reasonix/default.nix
@@ -7,15 +7,15 @@
 
 buildGoModule rec {
   pname = "deepseek-reasonix";
-  version = "1.17.17";
+  version = "1.17.19";
   src = fetchFromGitHub {
     owner = "esengine";
     repo = "DeepSeek-Reasonix";
     rev = "v${version}";
-    sha256 = "sha256-pyK7XeabaVH7cazcoFuGvxJ5rGKmaP8U1PBWFncrI0I=";
+    sha256 = "sha256-J8rYnly/wHSVcdudKmaNLyD1uD/xzETkrEIzsVz9UQ0=";
   };
 
-  vendorHash = "sha256-oy51NImtaG9tP5NbgR9N9nLYsgoDqNwj2G4h3HkHFFY=";
+  vendorHash = "sha256-Byt7/DbSHZ+PJ8evWARRQHds/kyuydTyYH98pFwAxNY=";
 
   subPackages = [
     "cmd/reasonix"


### PR DESCRIPTION
###### Changelog

```text
deepseek-reasonix: 1.17.17 -> 1.17.19

Diff: https://github.com/esengine/DeepSeek-Reasonix/compare/v1.17.17...v1.17.19
cowrie: v3.0.8 -> v3.0.9
linux-intel-lts: lts-v6.18.37-linux-260713T060441Z -> lts-v6.18.38-linux-260717T053932Z
moe-koe-music: v1.6.8 -> v1.6.9
```
