### PR TITLE
Automated update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786862985,
-        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
+        "lastModified": 1787001381,
+        "narHash": "sha256-Ue1Yo8gfHdD4TMtNewhA4tkSYeFqXThju0nCyJc3ALo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
+        "rev": "ec2d622de0773551768cf98f3fc50cbcc003b9c5",
         "type": "github"
       },
       "original": {

--- a/pkgs/deepseek-reasonix/default.nix
+++ b/pkgs/deepseek-reasonix/default.nix
@@ -7,12 +7,12 @@
 
 buildGoModule rec {
   pname = "deepseek-reasonix";
-  version = "1.27.0";
+  version = "1.28.0";
   src = fetchFromGitHub {
     owner = "esengine";
     repo = "DeepSeek-Reasonix";
     rev = "v${version}";
-    sha256 = "sha256-3dEFIG03YG2YSla8DYQNsmiCo+mH9bdlRZvjBLH8+FE=";
+    sha256 = "sha256-VycoYesj/WD790lYh/oxUgjC+lrQthdWRXRSC2yerDQ=";
   };
 
   vendorHash = "sha256-dCPVp5E+d2HcnSlCsQSebK8THdai1XjyKCKQlfpj80I=";


### PR DESCRIPTION
###### Changelog

```text
deepseek-reasonix: 1.27.0 -> 1.28.0

Diff: https://github.com/esengine/DeepSeek-Reasonix/compare/v1.27.0...v1.28.0
```
