### PR TITLE
Automated update

### DIFF
--- a/pkgs/deepseek-reasonix/default.nix
+++ b/pkgs/deepseek-reasonix/default.nix
@@ -7,12 +7,12 @@
 
 buildGoModule rec {
   pname = "deepseek-reasonix";
-  version = "1.28.0";
+  version = "1.29.0";
   src = fetchFromGitHub {
     owner = "esengine";
     repo = "DeepSeek-Reasonix";
     rev = "v${version}";
-    sha256 = "sha256-VycoYesj/WD790lYh/oxUgjC+lrQthdWRXRSC2yerDQ=";
+    sha256 = "sha256-yEBNU/JYZkG2oSRaN4trLnbnQF5Fl05LCltLBUuRlNA=";
   };
 
   vendorHash = "sha256-dCPVp5E+d2HcnSlCsQSebK8THdai1XjyKCKQlfpj80I=";


### PR DESCRIPTION
###### Changelog

```text
deepseek-reasonix: 1.28.0 -> 1.29.0

Diff: https://github.com/esengine/DeepSeek-Reasonix/compare/v1.28.0...v1.29.0
```
